### PR TITLE
fix bug to show complete country name

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,4 +74,4 @@ group :development do
 end
 
 gem 'faker'
-gem 'country_select'
+gem 'country_select', '~> 8.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,10 +88,10 @@ GEM
     builder (3.3.0)
     concurrent-ruby (1.3.4)
     connection_pool (2.4.1)
-    countries (7.0.0)
+    countries (5.7.2)
       unaccent (~> 0.3)
-    country_select (10.0.0)
-      countries (> 5.0, < 8.0)
+    country_select (8.0.3)
+      countries (~> 5.0)
     crass (1.0.6)
     date (3.3.4)
     debug (1.9.2)
@@ -270,7 +270,7 @@ DEPENDENCIES
   autoprefixer-rails
   bootsnap
   bootstrap (~> 5.2)
-  country_select
+  country_select (~> 8.0)
   debug
   error_highlight (>= 0.4.0)
   faker

--- a/app/views/creators/show.html.erb
+++ b/app/views/creators/show.html.erb
@@ -2,7 +2,11 @@
   <h1>more info about <%= @creator.name %></h1>
   <%= link_to "regresar", creators_path %>
   <h2><strong>Age: </strong><%=  @creator.age %></h2>
-  <h2><strong>Country: </strong><%=  @creator.country %></h2>
+  <h2><strong>Country: </strong><%= if ISO3166::Country[@creator.country]
+      ISO3166::Country[@creator.country]
+    else
+      @creator.country
+    end %></h2>
   <h2><strong>Awards: </strong><%=  @creator.awards %></h2>
   <h2><strong>Career: </strong><%=  @creator.career %></h2>
   <h2><strong>Still writing? : </strong><%= @creator.active ? "Yes" : "No" %></h2>


### PR DESCRIPTION
fixed bug to show complete country name but still missing to show the name of country that comes from seed does not show in edit view but yes in show view
basically if I used the country gem to create it shows but if not it does not retrives the info and shows it empty unles I edit it